### PR TITLE
Extract auth module, cache MCP client, extend JWT lifetime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ Apple Music playlist creator — CLI tool and MCP server for searching the Apple
 ```
 playlist_creator/
   __init__.py
-  apple_music.py      # AppleMusicClient — JWT auth, catalog search, playlist CRUD
+  auth.py             # AppleMusicAuth — JWT token generation and auth headers
+  apple_music.py      # AppleMusicClient — catalog search, playlist CRUD
   parser.py           # Markdown parser — extracts playlist name, description, tracks
   mcp_server.py       # MCP server (FastMCP, stdio transport) wrapping AppleMusicClient
   cli.py              # CLI entry point

--- a/generate_apple_music_token.py
+++ b/generate_apple_music_token.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from playlist_creator.apple_music import AppleMusicConfig
+from playlist_creator.auth import AppleMusicConfig
 
 load_dotenv()
 

--- a/playlist_creator/apple_music.py
+++ b/playlist_creator/apple_music.py
@@ -2,69 +2,30 @@
 
 from __future__ import annotations
 
-import time
-from dataclasses import dataclass
 from typing import Any
 
-import jwt
 import requests
 
+from .auth import AppleMusicAuth, AppleMusicConfig  # noqa: F401 — re-exported
+
 APPLE_MUSIC_API = "https://api.music.apple.com/v1"
-
-
-@dataclass
-class AppleMusicConfig:
-    team_id: str
-    key_id: str
-    private_key: str  # PEM-encoded private key contents
-    storefront: str = "us"
 
 
 class AppleMusicClient:
     """Client for Apple Music API operations."""
 
-    def __init__(self, config: AppleMusicConfig, user_token: str) -> None:
-        self.config = config
-        self.user_token = user_token
-        self._developer_token: str | None = None
-        self._token_expiry: float = 0
+    def __init__(self, auth: AppleMusicAuth) -> None:
+        self.auth = auth
 
     @property
-    def developer_token(self) -> str:
-        now = time.time()
-        if self._developer_token and now < self._token_expiry:
-            return self._developer_token
-
-        expiry = now + 3600  # 1 hour
-        payload = {
-            "iss": self.config.team_id,
-            "iat": int(now),
-            "exp": int(expiry),
-        }
-        token = jwt.encode(
-            payload,
-            self.config.private_key,
-            algorithm="ES256",
-            headers={"kid": self.config.key_id},
-        )
-        self._developer_token = token
-        self._token_expiry = expiry - 60  # refresh 1 min early
-        return token
-
-    def _headers(self, *, include_user_token: bool = False) -> dict[str, str]:
-        headers = {
-            "Authorization": f"Bearer {self.developer_token}",
-            "Content-Type": "application/json",
-        }
-        if include_user_token:
-            headers["Music-User-Token"] = self.user_token
-        return headers
+    def storefront(self) -> str:
+        return self.auth.config.storefront
 
     def search_track(self, query: str) -> dict | None:
         """Search for a song and return the first match, or None."""
-        url = f"{APPLE_MUSIC_API}/catalog/{self.config.storefront}/search"
+        url = f"{APPLE_MUSIC_API}/catalog/{self.storefront}/search"
         params = {"term": query, "types": "songs", "limit": 1}
-        resp = requests.get(url, headers=self._headers(), params=params, timeout=30)
+        resp = requests.get(url, headers=self.auth.headers(), params=params, timeout=30)
         resp.raise_for_status()
 
         data = resp.json()
@@ -86,7 +47,7 @@ class AppleMusicClient:
         }
         resp = requests.post(
             url,
-            headers=self._headers(include_user_token=True),
+            headers=self.auth.headers(include_user_token=True),
             json=body,
             timeout=30,
         )
@@ -98,9 +59,9 @@ class AppleMusicClient:
         self, query: str, limit: int = 10, types: str = "songs"
     ) -> list[dict[str, Any]]:
         """Search the Apple Music catalog. Returns a list of result dicts."""
-        url = f"{APPLE_MUSIC_API}/catalog/{self.config.storefront}/search"
+        url = f"{APPLE_MUSIC_API}/catalog/{self.storefront}/search"
         params = {"term": query, "types": types, "limit": limit}
-        resp = requests.get(url, headers=self._headers(), params=params, timeout=30)
+        resp = requests.get(url, headers=self.auth.headers(), params=params, timeout=30)
         resp.raise_for_status()
 
         data = resp.json()
@@ -130,9 +91,9 @@ class AppleMusicClient:
         Returns a dict with artist info and a list of top songs.
         """
         # Step 1: Search for the artist
-        url = f"{APPLE_MUSIC_API}/catalog/{self.config.storefront}/search"
+        url = f"{APPLE_MUSIC_API}/catalog/{self.storefront}/search"
         params = {"term": artist_name, "types": "artists", "limit": 1}
-        resp = requests.get(url, headers=self._headers(), params=params, timeout=30)
+        resp = requests.get(url, headers=self.auth.headers(), params=params, timeout=30)
         resp.raise_for_status()
 
         data = resp.json()
@@ -146,12 +107,12 @@ class AppleMusicClient:
 
         # Step 2: Fetch top songs
         top_songs_url = (
-            f"{APPLE_MUSIC_API}/catalog/{self.config.storefront}"
+            f"{APPLE_MUSIC_API}/catalog/{self.storefront}"
             f"/artists/{artist_id}/view/top-songs"
         )
         params = {"limit": limit}
         resp = requests.get(
-            top_songs_url, headers=self._headers(), params=params, timeout=30
+            top_songs_url, headers=self.auth.headers(), params=params, timeout=30
         )
         resp.raise_for_status()
 
@@ -188,7 +149,7 @@ class AppleMusicClient:
         url = f"{APPLE_MUSIC_API}/me/library/playlists"
         resp = requests.get(
             url,
-            headers=self._headers(include_user_token=True),
+            headers=self.auth.headers(include_user_token=True),
             timeout=30,
         )
         resp.raise_for_status()
@@ -213,7 +174,7 @@ class AppleMusicClient:
         while True:
             resp = requests.get(
                 url,
-                headers=self._headers(include_user_token=True),
+                headers=self.auth.headers(include_user_token=True),
                 params=params,
                 timeout=30,
             )
@@ -263,7 +224,7 @@ class AppleMusicClient:
             body = {"data": to_add}
             resp = requests.post(
                 url,
-                headers=self._headers(include_user_token=True),
+                headers=self.auth.headers(include_user_token=True),
                 json=body,
                 timeout=30,
             )

--- a/playlist_creator/auth.py
+++ b/playlist_creator/auth.py
@@ -1,0 +1,62 @@
+"""Authentication for the Apple Music API.
+
+Handles JWT developer token generation and header construction.
+Separated from the API client so auth logic is reusable and testable independently.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import jwt
+
+
+@dataclass
+class AppleMusicConfig:
+    team_id: str
+    key_id: str
+    private_key: str  # PEM-encoded private key contents
+    storefront: str = "us"
+
+
+class AppleMusicAuth:
+    """Manages developer token generation and auth headers."""
+
+    def __init__(self, config: AppleMusicConfig, user_token: str) -> None:
+        self.config = config
+        self.user_token = user_token
+        self._developer_token: str | None = None
+        self._token_expiry: float = 0
+
+    @property
+    def developer_token(self) -> str:
+        now = time.time()
+        if self._developer_token and now < self._token_expiry:
+            return self._developer_token
+
+        expiry = now + 15_777_000  # ~6 months (Apple's max)
+        payload = {
+            "iss": self.config.team_id,
+            "iat": int(now),
+            "exp": int(expiry),
+        }
+        token = jwt.encode(
+            payload,
+            self.config.private_key,
+            algorithm="ES256",
+            headers={"kid": self.config.key_id},
+        )
+        self._developer_token = token
+        self._token_expiry = expiry - 300  # refresh 5 min early
+        return token
+
+    def headers(self, *, include_user_token: bool = False) -> dict[str, str]:
+        """Return auth headers for Apple Music API requests."""
+        h = {
+            "Authorization": f"Bearer {self.developer_token}",
+            "Content-Type": "application/json",
+        }
+        if include_user_token:
+            h["Music-User-Token"] = self.user_token
+        return h

--- a/playlist_creator/cli.py
+++ b/playlist_creator/cli.py
@@ -9,7 +9,8 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from .apple_music import AppleMusicClient, AppleMusicConfig
+from .apple_music import AppleMusicClient
+from .auth import AppleMusicAuth, AppleMusicConfig
 from .parser import Track, parse_markdown
 
 load_dotenv()
@@ -42,8 +43,8 @@ def _build_client() -> AppleMusicClient:
         private_key=private_key,
         storefront=os.environ.get("APPLE_MUSIC_STOREFRONT", "us"),
     )
-    user_token = _get_env("APPLE_MUSIC_USER_TOKEN")
-    return AppleMusicClient(config, user_token)
+    auth = AppleMusicAuth(config, user_token=_get_env("APPLE_MUSIC_USER_TOKEN"))
+    return AppleMusicClient(auth)
 
 
 def _search_track(client: AppleMusicClient, track: Track, verbose: bool) -> dict | None:

--- a/playlist_creator/mcp_server.py
+++ b/playlist_creator/mcp_server.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
-from .apple_music import AppleMusicClient, AppleMusicConfig
+from .apple_music import AppleMusicClient
+from .auth import AppleMusicAuth, AppleMusicConfig
 from .parser import parse_markdown_text
 
 load_dotenv()
@@ -17,6 +18,8 @@ load_dotenv()
 logger = logging.getLogger("apple-music-mcp")
 
 mcp = FastMCP("apple-music")
+
+_client: AppleMusicClient | None = None
 
 
 def _get_env(name: str) -> str:
@@ -27,8 +30,12 @@ def _get_env(name: str) -> str:
     return value
 
 
-def _build_client() -> AppleMusicClient:
-    """Build an AppleMusicClient from environment variables."""
+def _get_client() -> AppleMusicClient:
+    """Return a cached AppleMusicClient, building it on first call."""
+    global _client
+    if _client is not None:
+        return _client
+
     key_path = os.environ.get("APPLE_PRIVATE_KEY_PATH")
     private_key = os.environ.get("APPLE_PRIVATE_KEY")
 
@@ -48,8 +55,9 @@ def _build_client() -> AppleMusicClient:
         private_key=private_key,
         storefront=os.environ.get("APPLE_MUSIC_STOREFRONT", "us"),
     )
-    user_token = _get_env("APPLE_MUSIC_USER_TOKEN")
-    return AppleMusicClient(config, user_token)
+    auth = AppleMusicAuth(config, user_token=_get_env("APPLE_MUSIC_USER_TOKEN"))
+    _client = AppleMusicClient(auth)
+    return _client
 
 
 def _handle_api_error(e: Exception) -> str:
@@ -79,7 +87,7 @@ def search_catalog(query: str, limit: int = 10, types: str = "songs") -> dict[st
     """
     logger.info("search_catalog query=%r limit=%d types=%s", query, limit, types)
     try:
-        client = _build_client()
+        client = _get_client()
         results = client.search_catalog(query, limit=limit, types=types)
         logger.info("search_catalog returned %d results", len(results))
         return {"results": results}
@@ -102,7 +110,7 @@ def get_artist_top_songs(artist: str, limit: int = 20, lead_artist_only: bool = 
     """
     logger.info("get_artist_top_songs artist=%r limit=%d lead_artist_only=%s", artist, limit, lead_artist_only)
     try:
-        client = _build_client()
+        client = _get_client()
         result = client.get_artist_top_songs(artist, limit=limit, lead_artist_only=lead_artist_only)
         if result["artist"] is None:
             logger.warning("get_artist_top_songs: artist not found for %r", artist)
@@ -128,7 +136,7 @@ def create_playlist(name: str, description: str = "") -> dict[str, object]:
     """
     logger.info("create_playlist name=%r", name)
     try:
-        client = _build_client()
+        client = _get_client()
         playlist_id = client.create_playlist(name, description)
         logger.info("create_playlist created id=%s", playlist_id)
         return {"id": playlist_id, "name": name}
@@ -147,7 +155,7 @@ def add_to_playlist(playlist_id: str, song_ids: list[str]) -> dict[str, object]:
     """
     logger.info("add_to_playlist playlist_id=%s songs=%d", playlist_id, len(song_ids))
     try:
-        client = _build_client()
+        client = _get_client()
         track_data = [{"id": sid, "type": "songs"} for sid in song_ids]
         result = client.add_tracks_to_playlist(playlist_id, track_data)
         added = result["added"]
@@ -168,7 +176,7 @@ def list_playlists() -> dict[str, object]:
     """List the user's Apple Music library playlists."""
     logger.info("list_playlists")
     try:
-        client = _build_client()
+        client = _get_client()
         playlists = client.list_playlists()
         logger.info("list_playlists returned %d playlists", len(playlists))
         return {"playlists": playlists}
@@ -190,7 +198,7 @@ def search_playlist(
     """
     logger.info("search_playlist playlist_id=%s query=%r", playlist_id, query)
     try:
-        client = _build_client()
+        client = _get_client()
         tracks = client.get_playlist_tracks(playlist_id)
         query_lower = query.lower()
         matches = [
@@ -231,7 +239,7 @@ def create_playlist_from_markdown(
         playlist_desc = description or playlist.description
         logger.info("parsed %d tracks from markdown, playlist=%r", len(playlist.tracks), playlist_name)
 
-        client = _build_client()
+        client = _get_client()
 
         matched: list[dict[str, str]] = []
         not_found: list[dict[str, str]] = []

--- a/tests/test_apple_music.py
+++ b/tests/test_apple_music.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from playlist_creator.apple_music import AppleMusicClient, AppleMusicConfig
+from playlist_creator.apple_music import AppleMusicClient
+from playlist_creator.auth import AppleMusicAuth, AppleMusicConfig
 
 
 @pytest.fixture
@@ -29,19 +30,24 @@ def config():
 
 
 @pytest.fixture
-def client(config):
-    return AppleMusicClient(config, user_token="test-user-token")
+def auth(config):
+    return AppleMusicAuth(config, user_token="test-user-token")
 
 
-def test_developer_token_generated(client):
-    token = client.developer_token
+@pytest.fixture
+def client(auth):
+    return AppleMusicClient(auth)
+
+
+def test_developer_token_generated(auth):
+    token = auth.developer_token
     assert isinstance(token, str)
     assert len(token) > 0
 
 
-def test_developer_token_cached(client):
-    token1 = client.developer_token
-    token2 = client.developer_token
+def test_developer_token_cached(auth):
+    token1 = auth.developer_token
+    token2 = auth.developer_token
     assert token1 == token2
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import playlist_creator.mcp_server as mcp_mod
 from playlist_creator.mcp_server import (
     add_to_playlist,
     create_playlist,
@@ -12,6 +13,14 @@ from playlist_creator.mcp_server import (
     list_playlists,
     search_catalog,
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_client_cache():
+    """Reset the cached MCP client between tests."""
+    mcp_mod._client = None
+    yield
+    mcp_mod._client = None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Extract `AppleMusicAuth` into `auth.py` — separates JWT generation and header construction from the API client, inspired by [Cifero74/mcp-apple-music](https://github.com/Cifero74/mcp-apple-music)'s architecture
- Cache the MCP server's `AppleMusicClient` as a module-level singleton instead of rebuilding on every tool call
- Extend JWT developer token lifetime from 1 hour to ~6 months (Apple's maximum)

## Test plan
- [x] All 26 existing tests pass
- [x] Verify MCP server tools work with cached client (manual test with Claude Desktop/Code)
- [x] Verify CLI still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)