### PR TITLE
Sync docs and skill with current codebase

### DIFF
--- a/.claude/skills/playlist/SKILL.md
+++ b/.claude/skills/playlist/SKILL.md
@@ -12,9 +12,11 @@ allowed-tools: Read, Glob
 You have access to an Apple Music MCP server with these tools:
 
 - `search_catalog(query, limit, types)` — Search Apple Music for songs, albums, or artists
+- `get_artist_top_songs(artist, limit, lead_artist_only)` — Get an artist's top songs sorted by popularity
 - `create_playlist(name, description)` — Create a new library playlist
 - `add_to_playlist(playlist_id, song_ids)` — Add songs by catalog ID
 - `list_playlists()` — List the user's library playlists
+- `search_playlist(playlist_id, query)` — Search within a playlist by title/artist/album
 - `create_playlist_from_markdown(markdown, name, description, dry_run)` — Parse markdown and create a playlist in one step
 
 ## Your task

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ tests/
   test_apple_music.py # API client tests (mocked)
   test_mcp_server.py  # MCP server tests
 examples/
-  road_trip.md        # Example markdown playlist
+  road_trip.md             # Example markdown playlist
+  iconic-mpc-producers.md  # Example large playlist (212 tracks)
 .claude/
   skills/playlist/    # /playlist skill for curating playlists via MCP tools
 ```
@@ -36,9 +37,11 @@ Copy `.env.example` to `.env` and fill in values. Required:
 |---|---|
 | `APPLE_TEAM_ID` | Apple Developer Team ID (10 chars) |
 | `APPLE_KEY_ID` | MusicKit key identifier (10 chars) |
-| `APPLE_PRIVATE_KEY_PATH` | Path to `.p8` private key file |
+| `APPLE_PRIVATE_KEY_PATH` | Path to `.p8` private key file (one of this or `APPLE_PRIVATE_KEY` required) |
+| `APPLE_PRIVATE_KEY` | PEM string, alternative to `APPLE_PRIVATE_KEY_PATH` |
 | `APPLE_MUSIC_USER_TOKEN` | Music User Token (from `get_user_token.html`) |
 | `APPLE_MUSIC_STOREFRONT` | Country code, defaults to `us` |
+| `LOG_LEVEL` | MCP server log level, defaults to `INFO` |
 
 ### Token generation
 


### PR DESCRIPTION
## Summary
- Add missing MCP tools (`get_artist_top_songs`, `search_playlist`) to playlist skill
- Add `APPLE_PRIVATE_KEY` and `LOG_LEVEL` env vars to CLAUDE.md
- Add `iconic-mpc-producers.md` to project structure tree

## Test plan
- [x] Verified all tools match `mcp_server.py` definitions
- [x] Verified env vars match actual usage in `mcp_server.py` and `cli.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)