### PR TITLE
Add discover, playlist-manage, and top-songs skills; make mcp required

### DIFF
--- a/.claude/skills/discover/SKILL.md
+++ b/.claude/skills/discover/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: discover
+description: Discover and recommend music — find similar artists, explore genres, and get personalized suggestions based on taste
+argument-hint: <artist, genre, mood, or "music like X">
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Music Discovery
+
+You have access to an Apple Music MCP server with these tools:
+
+- `search_catalog(query, limit, types)` — Search Apple Music for songs, albums, or artists
+- `get_artist_top_songs(artist, limit, lead_artist_only)` — Get an artist's top songs sorted by popularity
+
+## Your task
+
+Help the user discover music based on their request: **$ARGUMENTS**
+
+## Workflow
+
+### 1. Understand the request
+
+Determine what the user is looking for:
+- **Similar artists**: "artists like Radiohead", "if I like Bjork what else would I like"
+- **Genre exploration**: "best 90s trip-hop", "introduce me to shoegaze"
+- **Mood/vibe**: "dark ambient stuff", "upbeat funk"
+- **Artist deep-dive**: "I just discovered Khruangbin, where do I start"
+
+### 2. Use your music knowledge
+
+Draw on your knowledge of music history, genres, scenes, and artist connections to generate recommendations. Think about:
+- **Direct influences**: who influenced the artist, who they influenced
+- **Scene connections**: same label, same era, same city, collaborators
+- **Sonic similarity**: similar production style, instrumentation, mood
+- **Genre lineage**: subgenre roots and branches
+
+### 3. Verify and enrich with catalog searches
+
+For each recommendation, use `search_catalog` or `get_artist_top_songs` to:
+- Confirm the artist/album/song exists in Apple Music
+- Pull specific track names, albums, and catalog IDs
+- Get concrete "start here" tracks for each recommendation
+
+**Search strategy:**
+- Use `types: "artists"` to find artists, then `get_artist_top_songs` for their best tracks
+- Use `types: "songs"` when looking for specific tracks
+- Use `types: "albums"` when recommending full albums
+- If a search misses, try alternate spellings or shorter queries
+
+### 4. Present recommendations
+
+Structure your response clearly:
+- Group by relevance (closest matches first) or by theme/subgenre
+- For each artist/recommendation, include:
+  - Why they're relevant (the connection to the user's taste)
+  - 2-3 specific tracks or an album to start with
+  - A brief description of their sound
+- Aim for 5-10 recommendations unless the user asks for more or fewer
+- Distinguish between well-known picks and deeper cuts
+
+## Example interactions
+
+**"artists like Radiohead"**
+→ Recommend artists across Radiohead's influences (Talking Heads, Can), peers (Portishead, Massive Attack), and descendants (Everything Everything, Alt-J). Verify each in catalog, provide starting tracks.
+
+**"introduce me to Afrobeat"**
+→ Start with Fela Kuti as the origin, branch to Tony Allen, Antibalas, Mdou Moctar, KOKOROKO. Group by classic vs modern. Provide key albums and standout tracks.
+
+**"dark electronic music for late nights"**
+→ Think Burial, Andy Stott, Actress, Demdike Stare, Oneohtrix Point Never. Verify tracks, note the different flavors (dubstep, techno, ambient).
+
+**"I like Kendrick Lamar and Frank Ocean, what else?"**
+→ Find the intersection — artists who blend hip-hop with introspection and genre-bending: Isaiah Rashad, Sampha, SZA, Anderson .Paak, Noname. Pull top songs for each.
+
+## Tips
+
+- Don't just list obvious names — mix well-known with genuinely surprising picks
+- Explain *why* each recommendation connects, not just *what* to listen to
+- When the user names multiple artists, find the intersection of their tastes
+- If the user wants to turn recommendations into a playlist, suggest using `/playlist`
+- Catalog IDs from search results can be used directly with `/playlist` to build a playlist from discoveries

--- a/.claude/skills/playlist-manage/SKILL.md
+++ b/.claude/skills/playlist-manage/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: playlist-manage
+description: Manage existing Apple Music playlists — find duplicates, merge playlists, search across playlists, and inspect contents
+argument-hint: <action: list, search, duplicates, merge, or describe what you need>
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Playlist Manager
+
+You have access to an Apple Music MCP server with these tools:
+
+- `search_catalog(query, limit, types)` — Search Apple Music for songs, albums, or artists
+- `list_playlists()` — List the user's Apple Music library playlists
+- `search_playlist(playlist_id, query)` — Search within a playlist by title/artist/album
+- `add_to_playlist(playlist_id, song_ids)` — Add songs by catalog ID (skips duplicates)
+- `create_playlist(name, description)` — Create a new library playlist
+
+## Your task
+
+Help the user manage their Apple Music playlists: **$ARGUMENTS**
+
+## Workflow
+
+### 1. Understand the request
+
+Determine what the user needs:
+- **List/browse**: "show my playlists", "what playlists do I have"
+- **Search**: "find Radiohead across my playlists", "is this song in any playlist"
+- **Inspect**: "what's in my workout playlist", "how many tracks in X"
+- **Merge**: "combine my two jazz playlists into one"
+- **Find duplicates**: "are there duplicates in my playlist"
+- **Add tracks**: "add these songs to my existing playlist"
+
+### 2. Find the right playlist(s)
+
+Start with `list_playlists()` to see all available playlists. Match the user's description to playlist names — be flexible with matching (case-insensitive, partial matches).
+
+If the user is vague ("my workout playlist"), list playlists and pick the best match, or ask if ambiguous.
+
+### 3. Perform the action
+
+**Listing playlists:**
+- Call `list_playlists()` and present a clean table with name and track count
+
+**Searching within a playlist:**
+- Use `search_playlist(playlist_id, query)` to find specific tracks
+- Report matches with track details
+
+**Searching across playlists:**
+- Call `list_playlists()`, then `search_playlist` on each relevant playlist
+- Report which playlists contain the track
+
+**Finding duplicates within a playlist:**
+- Use `search_playlist` with artist names or song titles that might appear multiple times
+- Note: the API doesn't return full track lists directly, so search for specific artists/titles the user mentions, or ask what to check for
+
+**Merging playlists:**
+- Search the source playlists to identify tracks
+- Create a new playlist with `create_playlist` or add to an existing one with `add_to_playlist`
+- The `add_to_playlist` tool automatically skips duplicates
+
+**Adding tracks:**
+- Use `search_catalog` to find tracks by name
+- Use `add_to_playlist` to add them to the target playlist
+
+### 4. Report results
+
+Present results clearly:
+- Use tables for track listings
+- Show track counts and totals
+- Note any issues (tracks not found, duplicates skipped)
+
+## Example interactions
+
+**"show my playlists"**
+→ Call `list_playlists()`, display as a formatted list with names and track counts
+
+**"is Bohemian Rhapsody in any of my playlists?"**
+→ List playlists, search each for "Bohemian Rhapsody", report which ones contain it
+
+**"merge my 'Chill Vibes' and 'Sunday Morning' playlists"**
+→ List playlists to find both, search each to understand contents, create a new merged playlist or add contents of one to the other
+
+**"add the top 5 Tame Impala songs to my psychedelic playlist"**
+→ Find the playlist via `list_playlists`, search catalog for Tame Impala tracks, add to playlist
+
+## Tips
+
+- Always start with `list_playlists()` to get accurate playlist IDs — never guess IDs
+- `add_to_playlist` handles duplicate prevention automatically
+- When merging, ask the user if they want a new playlist or to add to one of the existing ones
+- Playlist IDs are opaque strings — always look them up, never hardcode

--- a/.claude/skills/playlist/SKILL.md
+++ b/.claude/skills/playlist/SKILL.md
@@ -4,7 +4,6 @@ description: Create Apple Music playlists using MCP tools — search catalog, cu
 argument-hint: <description of playlist to create>
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: Read, Glob
 ---
 
 # Apple Music Playlist Creator

--- a/.claude/skills/top-songs/SKILL.md
+++ b/.claude/skills/top-songs/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: top-songs
+description: Get an artist's top songs or compare top tracks across multiple artists
+argument-hint: <artist name, or "compare: Artist1 vs Artist2">
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Top Songs
+
+You have access to an Apple Music MCP server with these tools:
+
+- `get_artist_top_songs(artist, limit, lead_artist_only)` — Get an artist's top songs sorted by popularity
+- `search_catalog(query, limit, types)` — Search Apple Music for songs, albums, or artists
+
+## Your task
+
+Show the user top songs for the requested artist(s): **$ARGUMENTS**
+
+## Workflow
+
+### 1. Understand the request
+
+Determine the mode:
+- **Single artist**: "top songs by MF DOOM", "best Stevie Wonder tracks"
+- **Compare artists**: "compare Kendrick vs J. Cole", "top songs: Drake, Future, Metro Boomin"
+- **Filtered**: "top Radiohead songs that aren't from OK Computer", "solo work only"
+
+### 2. Fetch top songs
+
+Use `get_artist_top_songs` for each artist:
+- Default `limit=20` for single artist, `limit=10` for comparisons
+- Set `lead_artist_only=True` by default to exclude features — set to `False` if the user wants everything or asks for features/collaborations
+- If the artist name is ambiguous, search first with `search_catalog(query, types="artists")` to confirm
+
+### 3. Present results
+
+**Single artist — format as a numbered list:**
+```
+## Top Songs by [Artist]
+
+ #  | Title                  | Album                | Duration
+----|------------------------|----------------------|---------
+ 1  | Song Name              | Album Name           | 3:45
+ 2  | ...                    | ...                  | ...
+```
+
+Include:
+- Track number, title, album, duration
+- Total duration at the bottom
+
+**Comparison — format as side-by-side or sequential sections:**
+```
+## [Artist 1] vs [Artist 2]
+
+### [Artist 1] — Top 10
+(numbered list with title, album, duration)
+
+### [Artist 2] — Top 10
+(numbered list with title, album, duration)
+```
+
+Add a brief commentary comparing the two — most popular era, genre range, solo vs collaboration ratio, etc.
+
+### 4. Offer next steps
+
+After presenting results, suggest relevant follow-ups:
+- "Want me to create a playlist from these?" → `/playlist`
+- "Want to discover similar artists?" → `/discover`
+- "Want to add any of these to an existing playlist?" → `/playlist-manage`
+
+## Example interactions
+
+**"top songs by MF DOOM"**
+→ `get_artist_top_songs("MF DOOM", limit=20, lead_artist_only=True)`, format as numbered table
+
+**"compare Kendrick vs J. Cole"**
+→ Fetch top 10 for each, present side by side, add brief comparison commentary
+
+**"top songs: Drake, Future, Metro Boomin"**
+→ Fetch top 10 for each, present in sections, note any overlapping collaborations
+
+**"Radiohead deep cuts — skip the obvious ones"**
+→ Fetch top 20, use your music knowledge to call out which are the well-known hits vs deeper cuts, or fetch more and highlight tracks ranked lower
+
+## Tips
+
+- `duration_ms` from results can be converted to `m:ss` format for display
+- For artists with name collisions (e.g., "The National" vs "National"), verify with `search_catalog(types="artists")` first
+- `lead_artist_only=True` filters out features — useful for prolific collaborators
+- If the user asks for "best" rather than "top", add your own music-knowledge commentary on which tracks are critically acclaimed vs just popular

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,10 @@ examples/
   road_trip.md             # Example markdown playlist
   iconic-mpc-producers.md  # Example large playlist (212 tracks)
 .claude/
-  skills/playlist/    # /playlist skill for curating playlists via MCP tools
+  skills/playlist/         # /playlist — curate and create playlists via MCP tools
+  skills/discover/         # /discover — music recommendations and artist exploration
+  skills/playlist-manage/  # /playlist-manage — inspect, search, and merge playlists
+  skills/top-songs/        # /top-songs — artist top songs and comparisons
 ```
 
 ## Setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "apple_music_mcp"}]
 [tool.poetry.dependencies]
 python = "^3.10"
 cryptography = "^41.0"
-mcp = {version = "*", optional = true}
+mcp = "*"
 PyJWT = "^2.8"
 python-dotenv = "^1.2.2"
 requests = "^2.31"
@@ -17,9 +17,6 @@ requests = "^2.31"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"
 pytest-mock = "^3.0"
-
-[tool.poetry.extras]
-mcp = ["mcp"]
 
 [tool.poetry.scripts]
 playlist-creator = "apple_music_mcp.cli:main"


### PR DESCRIPTION
## Summary
- Add three new skills: `/discover` (music recommendations), `/playlist-manage` (inspect/search/merge playlists), `/top-songs` (artist top songs and comparisons)
- Make `mcp` a required dependency instead of an optional extra — it's the core purpose of the project
- Remove unsupported `allowed-tools` attribute from `/playlist` skill frontmatter
- Update CLAUDE.md project structure with all new skills

## Test plan
- [x] `poetry install` succeeds with mcp as required dep
- [x] All 26 tests pass
- [x] Skills load correctly in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)