### PR TITLE
Add library browsing, search, recently played, and recommendations tools

### DIFF
--- a/.claude/skills/discover/SKILL.md
+++ b/.claude/skills/discover/SKILL.md
@@ -12,6 +12,9 @@ You have access to an Apple Music MCP server with these tools:
 
 - `search_catalog(query, limit, types)` — Search Apple Music for songs, albums, or artists
 - `get_artist_top_songs(artist, limit, lead_artist_only)` — Get an artist's top songs sorted by popularity
+- `get_recently_played(limit)` — Get recently played albums/playlists/stations
+- `get_recommendations(limit)` — Get personalized recommendation groups from Apple Music
+- `search_library(query, types, limit)` — Search the user's library
 
 ## Your task
 

--- a/.claude/skills/playlist-manage/SKILL.md
+++ b/.claude/skills/playlist-manage/SKILL.md
@@ -12,7 +12,12 @@ You have access to an Apple Music MCP server with these tools:
 
 - `search_catalog(query, limit, types)` — Search Apple Music for songs, albums, or artists
 - `list_playlists()` — List the user's Apple Music library playlists
+- `get_playlist_tracks(playlist_id, limit)` — Get all tracks in a playlist
 - `search_playlist(playlist_id, query)` — Search within a playlist by title/artist/album
+- `search_library(query, types, limit)` — Search the user's library (songs, albums, artists, playlists)
+- `get_library_songs(limit, offset)` — Browse library songs with pagination
+- `get_library_albums(limit, offset)` — Browse library albums with pagination
+- `get_library_artists(limit, offset)` — Browse library artists with pagination
 - `add_to_playlist(playlist_id, song_ids)` — Add songs by catalog ID (skips duplicates)
 - `create_playlist(name, description)` — Create a new library playlist
 
@@ -52,8 +57,8 @@ If the user is vague ("my workout playlist"), list playlists and pick the best m
 - Report which playlists contain the track
 
 **Finding duplicates within a playlist:**
-- Use `search_playlist` with artist names or song titles that might appear multiple times
-- Note: the API doesn't return full track lists directly, so search for specific artists/titles the user mentions, or ask what to check for
+- Use `get_playlist_tracks` to get the full track list, then check for duplicate titles/artists
+- For quick checks on specific tracks, use `search_playlist` instead
 
 **Merging playlists:**
 - Search the source playlists to identify tracks

--- a/.claude/skills/playlist/SKILL.md
+++ b/.claude/skills/playlist/SKILL.md
@@ -15,6 +15,7 @@ You have access to an Apple Music MCP server with these tools:
 - `create_playlist(name, description)` — Create a new library playlist
 - `add_to_playlist(playlist_id, song_ids)` — Add songs by catalog ID
 - `list_playlists()` — List the user's library playlists
+- `get_playlist_tracks(playlist_id, limit)` — Get all tracks in a playlist
 - `search_playlist(playlist_id, query)` — Search within a playlist by title/artist/album
 - `create_playlist_from_markdown(markdown, name, description, dry_run)` — Parse markdown and create a playlist in one step
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,14 @@ poetry run playlist-creator examples/road_trip.md -v           # create playlist
 | `create_playlist(name, description)` | Create a library playlist |
 | `add_to_playlist(playlist_id, song_ids)` | Add songs by catalog ID (skips duplicates) |
 | `list_playlists()` | List user's library playlists |
+| `get_playlist_tracks(playlist_id, limit)` | Get all tracks in a playlist |
 | `search_playlist(playlist_id, query)` | Search within a playlist by title/artist/album |
+| `search_library(query, types, limit)` | Search user's library (songs, albums, artists, playlists) |
+| `get_library_songs(limit, offset)` | Browse library songs with pagination |
+| `get_library_albums(limit, offset)` | Browse library albums with pagination |
+| `get_library_artists(limit, offset)` | Browse library artists with pagination |
+| `get_recently_played(limit)` | Recently played albums/playlists/stations |
+| `get_recommendations(limit)` | Personalized recommendation groups |
 | `create_playlist_from_markdown(markdown, name, description, dry_run)` | Parse markdown and create playlist |
 
 ## Testing

--- a/apple_music_mcp/apple_music.py
+++ b/apple_music_mcp/apple_music.py
@@ -204,6 +204,143 @@ class AppleMusicClient:
 
         return tracks
 
+    def search_library(
+        self, query: str, types: str = "library-songs,library-albums,library-artists,library-playlists", limit: int = 10
+    ) -> list[dict[str, Any]]:
+        """Search the user's library. Returns a list of result dicts."""
+        url = f"{APPLE_MUSIC_API}/me/library/search"
+        params = {"term": query, "types": types, "limit": limit}
+        resp = requests.get(
+            url, headers=self.auth.headers(include_user_token=True), params=params, timeout=30
+        )
+        resp.raise_for_status()
+
+        data = resp.json()
+        results = []
+        for type_key in types.split(","):
+            type_key = type_key.strip()
+            items = data.get("results", {}).get(type_key, {}).get("data", [])
+            for item in items:
+                attrs = item.get("attributes", {})
+                results.append({
+                    "id": item["id"],
+                    "type": item.get("type", type_key),
+                    "title": attrs.get("name", ""),
+                    "artist": attrs.get("artistName", ""),
+                    "album": attrs.get("albumName", ""),
+                    "duration_ms": attrs.get("durationInMillis", 0),
+                    "track_count": attrs.get("trackCount", 0),
+                })
+        return results
+
+    def get_library_songs(self, limit: int = 25, offset: int = 0) -> list[dict[str, Any]]:
+        """List songs in the user's library with pagination."""
+        url = f"{APPLE_MUSIC_API}/me/library/songs"
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        resp = requests.get(
+            url, headers=self.auth.headers(include_user_token=True), params=params, timeout=30
+        )
+        resp.raise_for_status()
+
+        results = []
+        for item in resp.json().get("data", []):
+            attrs = item.get("attributes", {})
+            results.append({
+                "id": item["id"],
+                "title": attrs.get("name", ""),
+                "artist": attrs.get("artistName", ""),
+                "album": attrs.get("albumName", ""),
+                "duration_ms": attrs.get("durationInMillis", 0),
+                "track_number": attrs.get("trackNumber", 0),
+            })
+        return results
+
+    def get_library_albums(self, limit: int = 25, offset: int = 0) -> list[dict[str, Any]]:
+        """List albums in the user's library with pagination."""
+        url = f"{APPLE_MUSIC_API}/me/library/albums"
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        resp = requests.get(
+            url, headers=self.auth.headers(include_user_token=True), params=params, timeout=30
+        )
+        resp.raise_for_status()
+
+        results = []
+        for item in resp.json().get("data", []):
+            attrs = item.get("attributes", {})
+            results.append({
+                "id": item["id"],
+                "name": attrs.get("name", ""),
+                "artist": attrs.get("artistName", ""),
+                "track_count": attrs.get("trackCount", 0),
+                "release_date": attrs.get("releaseDate", ""),
+            })
+        return results
+
+    def get_library_artists(self, limit: int = 25, offset: int = 0) -> list[dict[str, Any]]:
+        """List artists in the user's library with pagination."""
+        url = f"{APPLE_MUSIC_API}/me/library/artists"
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        resp = requests.get(
+            url, headers=self.auth.headers(include_user_token=True), params=params, timeout=30
+        )
+        resp.raise_for_status()
+
+        results = []
+        for item in resp.json().get("data", []):
+            attrs = item.get("attributes", {})
+            results.append({
+                "id": item["id"],
+                "name": attrs.get("name", ""),
+            })
+        return results
+
+    def get_recently_played(self, limit: int = 10) -> list[dict[str, Any]]:
+        """Get recently played items (albums, playlists, stations)."""
+        url = f"{APPLE_MUSIC_API}/me/recent/played"
+        params: dict[str, Any] = {"limit": limit}
+        resp = requests.get(
+            url, headers=self.auth.headers(include_user_token=True), params=params, timeout=30
+        )
+        resp.raise_for_status()
+
+        results = []
+        for item in resp.json().get("data", []):
+            attrs = item.get("attributes", {})
+            results.append({
+                "id": item["id"],
+                "type": item.get("type", ""),
+                "name": attrs.get("name", ""),
+                "artist": attrs.get("artistName", ""),
+            })
+        return results
+
+    def get_recommendations(self, limit: int = 5) -> list[dict[str, Any]]:
+        """Get personalized recommendations from Apple Music."""
+        url = f"{APPLE_MUSIC_API}/me/recommendations"
+        params: dict[str, Any] = {"limit": limit}
+        resp = requests.get(
+            url, headers=self.auth.headers(include_user_token=True), params=params, timeout=30
+        )
+        resp.raise_for_status()
+
+        results = []
+        for group in resp.json().get("data", []):
+            attrs = group.get("attributes", {})
+            items = []
+            for rel in group.get("relationships", {}).get("contents", {}).get("data", []):
+                rel_attrs = rel.get("attributes", {})
+                items.append({
+                    "id": rel["id"],
+                    "type": rel.get("type", ""),
+                    "name": rel_attrs.get("name", ""),
+                    "artist": rel_attrs.get("artistName", ""),
+                })
+            results.append({
+                "title": attrs.get("title", {}).get("stringForDisplay", ""),
+                "items": items,
+            })
+        return results
+
     def add_tracks_to_playlist(
         self, playlist_id: str, track_ids: list[dict[str, str]]
     ) -> dict[str, list[dict[str, str]]]:

--- a/apple_music_mcp/mcp_server.py
+++ b/apple_music_mcp/mcp_server.py
@@ -215,6 +215,148 @@ def search_playlist(
 
 
 @mcp.tool()
+def get_playlist_tracks(playlist_id: str, limit: int = 100) -> dict[str, object]:
+    """Get all tracks in a library playlist.
+
+    Args:
+        playlist_id: The library playlist ID.
+        limit: Maximum number of tracks to return (default 100).
+    """
+    logger.info("get_playlist_tracks playlist_id=%s limit=%d", playlist_id, limit)
+    try:
+        client = _get_client()
+        tracks = client.get_playlist_tracks(playlist_id)
+        if limit and len(tracks) > limit:
+            tracks = tracks[:limit]
+        logger.info("get_playlist_tracks returned %d tracks", len(tracks))
+        return {"tracks": tracks, "total": len(tracks)}
+    except Exception as e:
+        logger.error("get_playlist_tracks failed: %s", e)
+        raise ValueError(_handle_api_error(e))
+
+
+@mcp.tool()
+def search_library(
+    query: str,
+    types: str = "library-songs,library-albums,library-artists,library-playlists",
+    limit: int = 10,
+) -> dict[str, object]:
+    """Search the user's Apple Music library for songs, albums, artists, or playlists.
+
+    Args:
+        query: Search query string.
+        types: Comma-separated library resource types (default: all).
+        limit: Maximum results per type (default 10, max 25).
+    """
+    logger.info("search_library query=%r types=%s limit=%d", query, types, limit)
+    try:
+        client = _get_client()
+        results = client.search_library(query, types=types, limit=limit)
+        logger.info("search_library returned %d results", len(results))
+        return {"results": results}
+    except Exception as e:
+        logger.error("search_library failed: %s", e)
+        raise ValueError(_handle_api_error(e))
+
+
+@mcp.tool()
+def get_library_songs(limit: int = 25, offset: int = 0) -> dict[str, object]:
+    """List songs in the user's Apple Music library with pagination.
+
+    Args:
+        limit: Number of songs to return (1-100, default 25).
+        offset: Pagination offset (default 0).
+    """
+    logger.info("get_library_songs limit=%d offset=%d", limit, offset)
+    try:
+        client = _get_client()
+        songs = client.get_library_songs(limit=limit, offset=offset)
+        logger.info("get_library_songs returned %d songs", len(songs))
+        return {"songs": songs}
+    except Exception as e:
+        logger.error("get_library_songs failed: %s", e)
+        raise ValueError(_handle_api_error(e))
+
+
+@mcp.tool()
+def get_library_albums(limit: int = 25, offset: int = 0) -> dict[str, object]:
+    """List albums in the user's Apple Music library with pagination.
+
+    Args:
+        limit: Number of albums to return (1-100, default 25).
+        offset: Pagination offset (default 0).
+    """
+    logger.info("get_library_albums limit=%d offset=%d", limit, offset)
+    try:
+        client = _get_client()
+        albums = client.get_library_albums(limit=limit, offset=offset)
+        logger.info("get_library_albums returned %d albums", len(albums))
+        return {"albums": albums}
+    except Exception as e:
+        logger.error("get_library_albums failed: %s", e)
+        raise ValueError(_handle_api_error(e))
+
+
+@mcp.tool()
+def get_library_artists(limit: int = 25, offset: int = 0) -> dict[str, object]:
+    """List artists in the user's Apple Music library with pagination.
+
+    Args:
+        limit: Number of artists to return (1-100, default 25).
+        offset: Pagination offset (default 0).
+    """
+    logger.info("get_library_artists limit=%d offset=%d", limit, offset)
+    try:
+        client = _get_client()
+        artists = client.get_library_artists(limit=limit, offset=offset)
+        logger.info("get_library_artists returned %d artists", len(artists))
+        return {"artists": artists}
+    except Exception as e:
+        logger.error("get_library_artists failed: %s", e)
+        raise ValueError(_handle_api_error(e))
+
+
+@mcp.tool()
+def get_recently_played(limit: int = 10) -> dict[str, object]:
+    """Get the user's recently played items on Apple Music.
+
+    Returns recently played albums, playlists, and stations.
+
+    Args:
+        limit: Number of items to return (1-50, default 10).
+    """
+    logger.info("get_recently_played limit=%d", limit)
+    try:
+        client = _get_client()
+        items = client.get_recently_played(limit=limit)
+        logger.info("get_recently_played returned %d items", len(items))
+        return {"items": items}
+    except Exception as e:
+        logger.error("get_recently_played failed: %s", e)
+        raise ValueError(_handle_api_error(e))
+
+
+@mcp.tool()
+def get_recommendations(limit: int = 5) -> dict[str, object]:
+    """Get personalized music recommendations from Apple Music.
+
+    Returns recommendation groups with suggested albums, playlists, and more.
+
+    Args:
+        limit: Number of recommendation groups (1-10, default 5).
+    """
+    logger.info("get_recommendations limit=%d", limit)
+    try:
+        client = _get_client()
+        recs = client.get_recommendations(limit=limit)
+        logger.info("get_recommendations returned %d groups", len(recs))
+        return {"recommendations": recs}
+    except Exception as e:
+        logger.error("get_recommendations failed: %s", e)
+        raise ValueError(_handle_api_error(e))
+
+
+@mcp.tool()
 def create_playlist_from_markdown(
     markdown: str,
     name: str | None = None,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10,8 +10,15 @@ from apple_music_mcp.mcp_server import (
     add_to_playlist,
     create_playlist,
     create_playlist_from_markdown,
+    get_library_albums,
+    get_library_artists,
+    get_library_songs,
+    get_playlist_tracks,
+    get_recently_played,
+    get_recommendations,
     list_playlists,
     search_catalog,
+    search_library,
 )
 
 
@@ -156,6 +163,222 @@ class TestListPlaylists:
         result = list_playlists()
         assert len(result["playlists"]) == 1
         assert result["playlists"][0]["name"] == "Late Night Ambient"
+
+
+class TestGetPlaylistTracks:
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_returns_tracks(self, mock_get, mock_env):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "data": [
+                {
+                    "id": "i.abc123",
+                    "attributes": {
+                        "name": "Rhubarb",
+                        "artistName": "Aphex Twin",
+                        "albumName": "SAW II",
+                        "durationInMillis": 312000,
+                        "trackNumber": 3,
+                        "playParams": {"catalogId": "999"},
+                    },
+                }
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = get_playlist_tracks("p.abc123")
+        assert len(result["tracks"]) == 1
+        assert result["tracks"][0]["title"] == "Rhubarb"
+        assert result["tracks"][0]["catalog_id"] == "999"
+
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_respects_limit(self, mock_get, mock_env):
+        tracks = [
+            {
+                "id": f"i.{i}",
+                "attributes": {
+                    "name": f"Track {i}",
+                    "artistName": "Artist",
+                    "albumName": "Album",
+                    "durationInMillis": 180000,
+                    "trackNumber": i,
+                    "playParams": {"catalogId": str(i)},
+                },
+            }
+            for i in range(5)
+        ]
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": tracks}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = get_playlist_tracks("p.abc123", limit=3)
+        assert len(result["tracks"]) == 3
+
+
+class TestSearchLibrary:
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_returns_results(self, mock_get, mock_env):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "results": {
+                "library-songs": {
+                    "data": [
+                        {
+                            "id": "i.abc",
+                            "type": "library-songs",
+                            "attributes": {
+                                "name": "Rhubarb",
+                                "artistName": "Aphex Twin",
+                                "albumName": "SAW II",
+                                "durationInMillis": 312000,
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = search_library("Aphex Twin", types="library-songs")
+        assert len(result["results"]) == 1
+        assert result["results"][0]["title"] == "Rhubarb"
+
+
+class TestGetLibrarySongs:
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_returns_songs(self, mock_get, mock_env):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {
+                    "id": "i.abc",
+                    "attributes": {
+                        "name": "Rhubarb",
+                        "artistName": "Aphex Twin",
+                        "albumName": "SAW II",
+                        "durationInMillis": 312000,
+                        "trackNumber": 3,
+                    },
+                }
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = get_library_songs(limit=10)
+        assert len(result["songs"]) == 1
+        assert result["songs"][0]["title"] == "Rhubarb"
+
+
+class TestGetLibraryAlbums:
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_returns_albums(self, mock_get, mock_env):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {
+                    "id": "l.abc",
+                    "attributes": {
+                        "name": "Selected Ambient Works Volume II",
+                        "artistName": "Aphex Twin",
+                        "trackCount": 24,
+                        "releaseDate": "1994-11-07",
+                    },
+                }
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = get_library_albums(limit=10)
+        assert len(result["albums"]) == 1
+        assert result["albums"][0]["name"] == "Selected Ambient Works Volume II"
+
+
+class TestGetLibraryArtists:
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_returns_artists(self, mock_get, mock_env):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {
+                    "id": "r.abc",
+                    "attributes": {"name": "Aphex Twin"},
+                }
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = get_library_artists(limit=10)
+        assert len(result["artists"]) == 1
+        assert result["artists"][0]["name"] == "Aphex Twin"
+
+
+class TestGetRecentlyPlayed:
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_returns_items(self, mock_get, mock_env):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {
+                    "id": "l.abc",
+                    "type": "albums",
+                    "attributes": {
+                        "name": "SAW II",
+                        "artistName": "Aphex Twin",
+                    },
+                }
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = get_recently_played(limit=5)
+        assert len(result["items"]) == 1
+        assert result["items"][0]["name"] == "SAW II"
+        assert result["items"][0]["type"] == "albums"
+
+
+class TestGetRecommendations:
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_returns_recommendations(self, mock_get, mock_env):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {
+                    "attributes": {
+                        "title": {"stringForDisplay": "Made for You"},
+                    },
+                    "relationships": {
+                        "contents": {
+                            "data": [
+                                {
+                                    "id": "pl.abc",
+                                    "type": "playlists",
+                                    "attributes": {
+                                        "name": "New Music Mix",
+                                        "artistName": "",
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                }
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = get_recommendations(limit=5)
+        assert len(result["recommendations"]) == 1
+        assert result["recommendations"][0]["title"] == "Made for You"
+        assert len(result["recommendations"][0]["items"]) == 1
 
 
 class TestCreatePlaylistFromMarkdown:


### PR DESCRIPTION
## Summary
- Add 7 new MCP tools: `get_playlist_tracks`, `search_library`, `get_library_songs`, `get_library_albums`, `get_library_artists`, `get_recently_played`, `get_recommendations`
- Client methods with proper pagination, user token auth, and consistent response shapes
- 8 new tests (34 total, all passing)
- Updated CLAUDE.md tools table and all 4 skills with new tool references

## Test plan
- [x] All 34 tests pass (`poetry run pytest`)
- [x] New tools follow existing patterns (error handling, logging, response format)
- [x] Skills reference correct tool names and signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)