### PR TITLE
Fix Pylance type errors

### DIFF
--- a/apple_music_mcp/apple_music.py
+++ b/apple_music_mcp/apple_music.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import requests
 
-from .auth import AppleMusicAuth, AppleMusicConfig  # noqa: F401 — re-exported
+from .auth import AppleMusicAuth, AppleMusicConfig as AppleMusicConfig  # noqa: F401 — re-exported
 
 APPLE_MUSIC_API = "https://api.music.apple.com/v1"
 
@@ -21,10 +21,10 @@ class AppleMusicClient:
     def storefront(self) -> str:
         return self.auth.config.storefront
 
-    def search_track(self, query: str) -> dict | None:
+    def search_track(self, query: str) -> dict[str, Any] | None:
         """Search for a song and return the first match, or None."""
         url = f"{APPLE_MUSIC_API}/catalog/{self.storefront}/search"
-        params = {"term": query, "types": "songs", "limit": 1}
+        params: dict[str, Any] = {"term": query, "types": "songs", "limit": 1}
         resp = requests.get(url, headers=self.auth.headers(), params=params, timeout=30)
         resp.raise_for_status()
 
@@ -39,7 +39,7 @@ class AppleMusicClient:
     ) -> str:
         """Create a new library playlist. Returns the playlist ID."""
         url = f"{APPLE_MUSIC_API}/me/library/playlists"
-        body: dict = {
+        body: dict[str, Any] = {
             "attributes": {
                 "name": name,
                 "description": description,
@@ -60,12 +60,12 @@ class AppleMusicClient:
     ) -> list[dict[str, Any]]:
         """Search the Apple Music catalog. Returns a list of result dicts."""
         url = f"{APPLE_MUSIC_API}/catalog/{self.storefront}/search"
-        params = {"term": query, "types": types, "limit": limit}
+        params: dict[str, Any] = {"term": query, "types": types, "limit": limit}
         resp = requests.get(url, headers=self.auth.headers(), params=params, timeout=30)
         resp.raise_for_status()
 
         data = resp.json()
-        results = []
+        results: list[dict[str, Any]] = []
         for type_key in types.split(","):
             type_key = type_key.strip()
             items = data.get("results", {}).get(type_key, {}).get("data", [])
@@ -92,7 +92,7 @@ class AppleMusicClient:
         """
         # Step 1: Search for the artist
         url = f"{APPLE_MUSIC_API}/catalog/{self.storefront}/search"
-        params = {"term": artist_name, "types": "artists", "limit": 1}
+        params: dict[str, Any] = {"term": artist_name, "types": "artists", "limit": 1}
         resp = requests.get(url, headers=self.auth.headers(), params=params, timeout=30)
         resp.raise_for_status()
 
@@ -110,7 +110,7 @@ class AppleMusicClient:
             f"{APPLE_MUSIC_API}/catalog/{self.storefront}"
             f"/artists/{artist_id}/view/top-songs"
         )
-        params = {"limit": limit}
+        params: dict[str, Any] = {"limit": limit}
         resp = requests.get(
             top_songs_url, headers=self.auth.headers(), params=params, timeout=30
         )
@@ -118,7 +118,7 @@ class AppleMusicClient:
 
         songs_data = resp.json()
         matched_name = artist_attrs.get("name", "").lower()
-        songs = []
+        songs: list[dict[str, Any]] = []
         for item in songs_data.get("data", []):
             attrs = item.get("attributes", {})
             song_artist = attrs.get("artistName", "")
@@ -155,7 +155,7 @@ class AppleMusicClient:
         resp.raise_for_status()
 
         data = resp.json()
-        playlists = []
+        playlists: list[dict[str, Any]] = []
         for item in data.get("data", []):
             attrs = item.get("attributes", {})
             playlists.append({
@@ -209,14 +209,14 @@ class AppleMusicClient:
     ) -> list[dict[str, Any]]:
         """Search the user's library. Returns a list of result dicts."""
         url = f"{APPLE_MUSIC_API}/me/library/search"
-        params = {"term": query, "types": types, "limit": limit}
+        params: dict[str, Any] = {"term": query, "types": types, "limit": limit}
         resp = requests.get(
             url, headers=self.auth.headers(include_user_token=True), params=params, timeout=30
         )
         resp.raise_for_status()
 
         data = resp.json()
-        results = []
+        results: list[dict[str, Any]] = []
         for type_key in types.split(","):
             type_key = type_key.strip()
             items = data.get("results", {}).get(type_key, {}).get("data", [])
@@ -242,7 +242,7 @@ class AppleMusicClient:
         )
         resp.raise_for_status()
 
-        results = []
+        results: list[dict[str, Any]] = []
         for item in resp.json().get("data", []):
             attrs = item.get("attributes", {})
             results.append({
@@ -264,7 +264,7 @@ class AppleMusicClient:
         )
         resp.raise_for_status()
 
-        results = []
+        results: list[dict[str, Any]] = []
         for item in resp.json().get("data", []):
             attrs = item.get("attributes", {})
             results.append({
@@ -285,7 +285,7 @@ class AppleMusicClient:
         )
         resp.raise_for_status()
 
-        results = []
+        results: list[dict[str, Any]] = []
         for item in resp.json().get("data", []):
             attrs = item.get("attributes", {})
             results.append({
@@ -303,7 +303,7 @@ class AppleMusicClient:
         )
         resp.raise_for_status()
 
-        results = []
+        results: list[dict[str, Any]] = []
         for item in resp.json().get("data", []):
             attrs = item.get("attributes", {})
             results.append({
@@ -323,10 +323,10 @@ class AppleMusicClient:
         )
         resp.raise_for_status()
 
-        results = []
+        results: list[dict[str, Any]] = []
         for group in resp.json().get("data", []):
             attrs = group.get("attributes", {})
-            items = []
+            items: list[dict[str, Any]] = []
             for rel in group.get("relationships", {}).get("contents", {}).get("data", []):
                 rel_attrs = rel.get("attributes", {})
                 items.append({

--- a/tests/test_apple_music.py
+++ b/tests/test_apple_music.py
@@ -9,7 +9,7 @@ from apple_music_mcp.auth import AppleMusicAuth, AppleMusicConfig
 
 
 @pytest.fixture
-def config():
+def config() -> AppleMusicConfig:
     # Minimal EC256 test key (not a real key, just for JWT encoding tests)
     from cryptography.hazmat.primitives.asymmetric import ec
     from cryptography.hazmat.primitives import serialization
@@ -30,29 +30,29 @@ def config():
 
 
 @pytest.fixture
-def auth(config):
+def auth(config: AppleMusicConfig) -> AppleMusicAuth:
     return AppleMusicAuth(config, user_token="test-user-token")
 
 
 @pytest.fixture
-def client(auth):
+def client(auth: AppleMusicAuth) -> AppleMusicClient:
     return AppleMusicClient(auth)
 
 
-def test_developer_token_generated(auth):
+def test_developer_token_generated(auth: AppleMusicAuth) -> None:
     token = auth.developer_token
     assert isinstance(token, str)
     assert len(token) > 0
 
 
-def test_developer_token_cached(auth):
+def test_developer_token_cached(auth: AppleMusicAuth) -> None:
     token1 = auth.developer_token
     token2 = auth.developer_token
     assert token1 == token2
 
 
 @patch("apple_music_mcp.apple_music.requests.get")
-def test_search_track_found(mock_get, client):
+def test_search_track_found(mock_get: MagicMock, client: AppleMusicClient) -> None:
     mock_resp = MagicMock()
     mock_resp.json.return_value = {
         "results": {
@@ -79,7 +79,7 @@ def test_search_track_found(mock_get, client):
 
 
 @patch("apple_music_mcp.apple_music.requests.get")
-def test_search_track_not_found(mock_get, client):
+def test_search_track_not_found(mock_get: MagicMock, client: AppleMusicClient) -> None:
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"results": {}}
     mock_resp.raise_for_status = MagicMock()
@@ -90,7 +90,7 @@ def test_search_track_not_found(mock_get, client):
 
 
 @patch("apple_music_mcp.apple_music.requests.post")
-def test_create_playlist(mock_post, client):
+def test_create_playlist(mock_post: MagicMock, client: AppleMusicClient) -> None:
     mock_resp = MagicMock()
     mock_resp.json.return_value = {
         "data": [{"id": "p.abc123", "type": "library-playlists"}]
@@ -107,7 +107,7 @@ def test_create_playlist(mock_post, client):
 
 @patch("apple_music_mcp.apple_music.requests.get")
 @patch("apple_music_mcp.apple_music.requests.post")
-def test_add_tracks_to_playlist(mock_post, mock_get, client):
+def test_add_tracks_to_playlist(mock_post: MagicMock, mock_get: MagicMock, client: AppleMusicClient) -> None:
     # Mock GET for get_playlist_tracks (returns empty playlist)
     mock_get_resp = MagicMock()
     mock_get_resp.status_code = 404


### PR DESCRIPTION
## Summary
- Add explicit `dict[str, Any]` and `list[dict[str, Any]]` type annotations to all bare `dict`/`list` types in `apple_music.py`
- Add type annotations to pytest fixture parameters and test functions in `test_apple_music.py`
- Use `as AppleMusicConfig` re-export idiom to satisfy Pylance's unused import check

## Test plan
- [x] All 34 tests pass
- [x] Zero Pylance diagnostics remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)