### PR TITLE
feat: add get_charts endpoint for Apple Music charts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ poetry run playlist-creator examples/road_trip.md -v           # create playlist
 | `get_library_songs(limit, offset)` | Browse library songs with pagination |
 | `get_library_albums(limit, offset)` | Browse library albums with pagination |
 | `get_library_artists(limit, offset)` | Browse library artists with pagination |
+| `get_charts(types, limit, genre)` | Top songs/albums/playlists charts by storefront |
 | `get_heavy_rotation(limit)` | User's most frequently played items |
 | `get_recently_played(limit)` | Recently played albums/playlists/stations |
 | `get_recommendations(limit)` | Personalized recommendation groups |

--- a/apple_music_mcp/apple_music.py
+++ b/apple_music_mcp/apple_music.py
@@ -363,6 +363,52 @@ class AppleMusicClient:
             )
         return results
 
+    def get_charts(
+        self,
+        types: str = "songs",
+        limit: int = 20,
+        genre: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Get Apple Music charts (top songs, albums, playlists) for the storefront.
+
+        Returns a list of chart groups, each with a name and entries.
+        """
+        url = f"{APPLE_MUSIC_API}/catalog/{self.storefront}/charts"
+        params: dict[str, Any] = {"types": types, "limit": limit}
+        if genre is not None:
+            params["genre"] = genre
+        resp = requests.get(url, headers=self.auth.headers(), params=params, timeout=30)
+        resp.raise_for_status()
+
+        results: list[dict[str, Any]] = []
+        for raw_key in types.split(","):
+            type_key = raw_key.strip()
+            chart_groups = resp.json().get("results", {}).get(type_key, [])
+            for group in chart_groups:
+                entries: list[dict[str, Any]] = []
+                for item in group.get("data", []):
+                    attrs = item.get("attributes", {})
+                    entries.append(
+                        {
+                            "id": item["id"],
+                            "title": attrs.get("name", ""),
+                            "artist": attrs.get("artistName", ""),
+                            "album": attrs.get("albumName", ""),
+                            "duration_ms": attrs.get("durationInMillis", 0),
+                            "genres": attrs.get("genreNames", []),
+                            "release_date": attrs.get("releaseDate", ""),
+                            "url": attrs.get("url", ""),
+                        }
+                    )
+                results.append(
+                    {
+                        "chart_name": group.get("name", ""),
+                        "chart": group.get("chart", ""),
+                        "entries": entries,
+                    }
+                )
+        return results
+
     def get_recently_played(self, limit: int = 10) -> list[dict[str, Any]]:
         """Get recently played items (albums, playlists, stations)."""
         url = f"{APPLE_MUSIC_API}/me/recent/played"

--- a/apple_music_mcp/mcp_server.py
+++ b/apple_music_mcp/mcp_server.py
@@ -358,6 +358,30 @@ def get_library_artists(limit: int = 25, offset: int = 0) -> dict[str, object]:
 
 
 @mcp.tool()
+def get_charts(
+    types: str = "songs", limit: int = 20, genre: str | None = None
+) -> dict[str, object]:
+    """Get Apple Music charts (top songs, top albums, top playlists) for the storefront.
+
+    Browse what's currently popular on Apple Music.
+
+    Args:
+        types: Comma-separated chart types: songs, albums, playlists (default "songs").
+        limit: Number of entries per chart (1-50, default 20).
+        genre: Optional Apple Music genre ID to filter charts (e.g. "14" for Pop).
+    """
+    logger.info("get_charts types=%s limit=%d genre=%s", types, limit, genre)
+    try:
+        client = _get_client()
+        charts = client.get_charts(types=types, limit=limit, genre=genre)
+        logger.info("get_charts returned %d chart groups", len(charts))
+        return {"charts": charts}
+    except Exception as e:
+        logger.error("get_charts failed: %s", e)
+        raise ValueError(_handle_api_error(e)) from e
+
+
+@mcp.tool()
 def get_heavy_rotation(limit: int = 10) -> dict[str, object]:
     """Get the user's heavy rotation (most frequently played items).
 

--- a/tests/test_apple_music.py
+++ b/tests/test_apple_music.py
@@ -588,6 +588,157 @@ class TestGetHeavyRotation:
         assert "Music-User-Token" in headers
 
 
+class TestGetCharts:
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_returns_chart_entries(
+        self, mock_get: MagicMock, client: AppleMusicClient
+    ) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "results": {
+                "songs": [
+                    {
+                        "name": "Top Songs",
+                        "chart": "most-played",
+                        "data": [
+                            {
+                                "id": "111",
+                                "type": "songs",
+                                "attributes": {
+                                    "name": "APT.",
+                                    "artistName": "ROSÉ & Bruno Mars",
+                                    "albumName": "rosie",
+                                    "durationInMillis": 170000,
+                                    "genreNames": ["Pop"],
+                                    "releaseDate": "2024-10-18",
+                                    "url": "https://music.apple.com/us/song/111",
+                                },
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = client.get_charts(types="songs", limit=10)
+        assert len(result) == 1
+        assert result[0]["chart_name"] == "Top Songs"
+        assert result[0]["chart"] == "most-played"
+        assert len(result[0]["entries"]) == 1
+        entry = result[0]["entries"][0]
+        assert entry["id"] == "111"
+        assert entry["title"] == "APT."
+        assert entry["artist"] == "ROSÉ & Bruno Mars"
+
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_multiple_chart_types(
+        self, mock_get: MagicMock, client: AppleMusicClient
+    ) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "results": {
+                "songs": [
+                    {
+                        "name": "Top Songs",
+                        "chart": "most-played",
+                        "data": [
+                            {
+                                "id": "111",
+                                "type": "songs",
+                                "attributes": {
+                                    "name": "Song",
+                                    "artistName": "Artist",
+                                    "albumName": "Album",
+                                    "durationInMillis": 200000,
+                                    "genreNames": [],
+                                    "releaseDate": "",
+                                    "url": "",
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "albums": [
+                    {
+                        "name": "Top Albums",
+                        "chart": "most-played",
+                        "data": [
+                            {
+                                "id": "222",
+                                "type": "albums",
+                                "attributes": {
+                                    "name": "Album",
+                                    "artistName": "Artist",
+                                    "albumName": "",
+                                    "durationInMillis": 0,
+                                    "genreNames": [],
+                                    "releaseDate": "",
+                                    "url": "",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = client.get_charts(types="songs,albums", limit=10)
+        assert len(result) == 2
+
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_empty_results(self, mock_get: MagicMock, client: AppleMusicClient) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"results": {}}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = client.get_charts(types="songs", limit=10)
+        assert result == []
+
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_passes_genre_param(
+        self, mock_get: MagicMock, client: AppleMusicClient
+    ) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"results": {}}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        client.get_charts(types="songs", limit=20, genre="14")
+        call_kwargs = mock_get.call_args
+        assert call_kwargs.kwargs["params"]["genre"] == "14"
+
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_no_genre_param_when_none(
+        self, mock_get: MagicMock, client: AppleMusicClient
+    ) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"results": {}}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        client.get_charts(types="songs", limit=10)
+        call_kwargs = mock_get.call_args
+        assert "genre" not in call_kwargs.kwargs["params"]
+
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_uses_storefront(
+        self, mock_get: MagicMock, client: AppleMusicClient
+    ) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"results": {}}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        client.get_charts(types="songs", limit=10)
+        call_url = mock_get.call_args.args[0]
+        assert "/catalog/us/charts" in call_url
+
+
 class TestAddToLibrary:
     @patch("apple_music_mcp.apple_music.requests.post")
     def test_sends_correct_request(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13,6 +13,7 @@ from apple_music_mcp.mcp_server import (
     create_playlist_from_markdown,
     get_album_details,
     get_artist_details,
+    get_charts,
     get_heavy_rotation,
     get_library_albums,
     get_library_artists,
@@ -325,6 +326,56 @@ class TestGetLibraryArtists:
         result = get_library_artists(limit=10)
         assert len(result["artists"]) == 1
         assert result["artists"][0]["name"] == "Aphex Twin"
+
+
+class TestGetCharts:
+    @patch("apple_music_mcp.apple_music.requests.get")
+    def test_returns_charts(self, mock_get, mock_env):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "results": {
+                "songs": [
+                    {
+                        "name": "Top Songs",
+                        "chart": "most-played",
+                        "data": [
+                            {
+                                "id": "111",
+                                "type": "songs",
+                                "attributes": {
+                                    "name": "APT.",
+                                    "artistName": "ROSÉ & Bruno Mars",
+                                    "albumName": "rosie",
+                                    "durationInMillis": 170000,
+                                    "genreNames": ["Pop"],
+                                    "releaseDate": "2024-10-18",
+                                    "url": "https://music.apple.com/us/song/111",
+                                },
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = get_charts(types="songs", limit=10)
+        assert len(result["charts"]) == 1
+        assert result["charts"][0]["chart_name"] == "Top Songs"
+        assert len(result["charts"][0]["entries"]) == 1
+
+    def test_api_error_handled(self, mock_env):
+        import requests
+
+        client = mcp_mod._get_client()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        error = requests.HTTPError(response=mock_resp)
+        with patch.object(client, "get_charts", side_effect=error):
+            mcp_mod._client = client
+            with pytest.raises(ValueError, match="User token expired"):
+                get_charts()
 
 
 class TestGetHeavyRotation:


### PR DESCRIPTION
## Summary
- Adds `get_charts(types, limit, genre)` to `AppleMusicClient` — calls `GET /v1/catalog/{storefront}/charts`
- Adds corresponding MCP tool wrapper for browsing top songs, albums, and playlists
- Supports optional genre filtering via Apple Music genre IDs

Closes #22

## Test plan
- [x] 6 unit tests for `AppleMusicClient.get_charts` (response mapping, multiple types, empty results, genre param, storefront URL)
- [x] 2 MCP server tests (returns charts, API error handling)
- [x] Full suite: 81 tests pass, 77.59% coverage
- [x] `ruff check`, `ruff format`, `mypy --strict` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)